### PR TITLE
Adds gender to profiles and fixes user relation handling

### DIFF
--- a/src/app/(main)/absensi/page.tsx
+++ b/src/app/(main)/absensi/page.tsx
@@ -82,16 +82,16 @@ export default function AbsensiPage() {
         ) : (
           <>
             {/* Reusable filter bar */}
-            <FilterBar
-              value={filter}
-              statuses={["Hadir", "Pulang"]}
-              onChange={(next) => {
-                setDate(next.date ?? "");
-                setQuery(next.query ?? "");
-                setStatus(next.status ?? "");
-                setSort(next.sort ?? "desc");
-              }}
-            />
+              <FilterBar
+                value={filter}
+                statuses={["Hadir", "Datang", "Pulang"]}
+                onChange={(next) => {
+                  setDate(next.date ?? "");
+                  setQuery(next.query ?? "");
+                  setStatus(next.status ?? "");
+                  setSort(next.sort ?? "desc");
+                }}
+              />
 
             {(() => {
               const rows = (absences ?? []).filter((a) => {

--- a/src/components/profiles/edit-profile-form.tsx
+++ b/src/components/profiles/edit-profile-form.tsx
@@ -14,6 +14,7 @@ type FormValues = {
   avatarUrl: string
   absenceNumber: string
   className: string
+  gender: 'Laki-laki' | 'Perempuan' | ''
   role: 'admin' | 'none'
   nis: string
 }
@@ -27,6 +28,7 @@ type Props = {
     avatarUrl: string | null
     absenceNumber: string | null
     className: string | null
+    gender: string | null
     role: string | null
     nis?: string | null
   }
@@ -42,6 +44,7 @@ export function EditProfileForm({ id, initialData }: Props) {
       avatarUrl: initialData.avatarUrl ?? '',
       absenceNumber: initialData.absenceNumber ?? '',
       className: initialData.className ?? '',
+      gender: (initialData.gender as FormValues['gender']) ?? '',
       role: initialData.role?.toLowerCase() === 'admin' ? 'admin' : 'none',
       nis: initialData.nis ?? '',
     }),
@@ -70,8 +73,8 @@ export function EditProfileForm({ id, initialData }: Props) {
     setIsDirty(true)
   }
 
-  const handleSelectChange = (value: string) => {
-    setFormValues((prev) => ({ ...prev, role: value as FormValues['role'] }))
+  const handleSelectChange = (value: string, field: keyof FormValues) => {
+    setFormValues((prev) => ({ ...prev, [field]: value }))
     setIsDirty(true)
   }
 
@@ -86,6 +89,7 @@ export function EditProfileForm({ id, initialData }: Props) {
         avatarUrl: v.avatarUrl || undefined,
         absenceNumber: v.absenceNumber || undefined,
         className: v.className || undefined,
+        gender: v.gender || undefined,
         role: v.role === 'admin' ? 'admin' : undefined,
         nis: v.nis || undefined,
       },
@@ -117,8 +121,20 @@ export function EditProfileForm({ id, initialData }: Props) {
           <Input id="absenceNumber" name="absenceNumber" value={formValues.absenceNumber} onChange={handleChange} />
         </div>
         <div className="space-y-2">
+          <Label htmlFor="gender">Gender</Label>
+          <Select value={formValues.gender} onValueChange={(value) => handleSelectChange(value, 'gender')}>
+            <SelectTrigger aria-label="Gender" id="gender">
+              <SelectValue placeholder="Pilih jenis kelamin" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="Laki-laki">Laki-laki</SelectItem>
+              <SelectItem value="Perempuan">Perempuan</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-2">
           <Label htmlFor="role">Role</Label>
-          <Select value={formValues.role} onValueChange={handleSelectChange}>
+          <Select value={formValues.role} onValueChange={(value) => handleSelectChange(value, 'role')}>
             <SelectTrigger aria-label="Role" id="role">
               <SelectValue placeholder="None" />
             </SelectTrigger>

--- a/src/server/api/routers/user-profiles.ts
+++ b/src/server/api/routers/user-profiles.ts
@@ -93,19 +93,15 @@ export const userProfilesRouter = createTRPCRouter({
 				className: z.string().optional(),
 				role: z.string().optional(),
 				nis: z.string().optional(),
+				gender: z.string().optional(),
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
 			const [row] = await ctx.db
 				.insert(userProfiles)
 				.values({
-					email: input.email,
-					fullName: input.fullName,
-					avatarUrl: input.avatarUrl,
-					absenceNumber: input.absenceNumber,
-					className: input.className,
-					role: input.role,
-					nis: input.nis,
+					...input,
+					userId: ctx.user.id, // Assuming userId comes from context
 				})
 				.returning();
 
@@ -126,6 +122,7 @@ export const userProfilesRouter = createTRPCRouter({
 						className: z.string().optional(),
 						role: z.string().optional(),
 						nis: z.string().optional(),
+						gender: z.string().optional(),
 					})
 					.refine((d) => Object.keys(d).length > 0, {
 						message: "No fields to update",
@@ -156,6 +153,7 @@ export const userProfilesRouter = createTRPCRouter({
 						className: z.string().optional(),
 						role: z.string().optional(),
 						nis: z.string().optional(),
+						gender: z.string().optional(),
 					})
 					.refine((d) => Object.keys(d).length > 0, {
 						message: "No fields to update",

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -127,7 +127,7 @@ export const perizinan = pgTable(
 export const perizinanRelations = relations(perizinan, ({ one }) => ({
   userProfile: one(userProfiles, {
     fields: [perizinan.userId],
-    references: [userProfiles.id],
+    references: [userProfiles.userId],
   }),
 }));
 


### PR DESCRIPTION
Adds a gender field to the profile edit UI and persists it through the API, enabling selection and storage of gender for user profiles. Adjusts the server-side profile router to accept gender, spread input values when creating profiles and explicitly associate new profiles with the authenticated user ID. Also corrects a relation reference in the DB schema so perizinan relates to the profile's userId column, preventing broken foreign-key resolution. Finally, expands the attendance filter options to include an additional status ("Datang").

These changes ensure gender is captured end-to-end, newly created profiles are properly linked to their owner, and attendance filtering covers the intended status set.