### PR TITLE
Tambahkan implementasi login admin

### DIFF
--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -25,15 +25,29 @@ export function LoginForm({
     e.preventDefault();
     setError(null);
     setLoading(true);
-    const { error: authError } = await supabase.auth.signInWithPassword({
+    
+    const { data, error: authError } = await supabase.auth.signInWithPassword({
       email,
       password,
     });
-    setLoading(false);
+    
     if (authError) {
+      setLoading(false);
       setError(authError.message);
       return;
     }
+
+    const userMetadata = data.user?.user_metadata;
+    const role = userMetadata?.role as string;
+
+    if (role !== "admin") {
+      setLoading(false);
+      await supabase.auth.signOut();
+      setError("Access denied. Admin role required.");
+      return;
+    }
+
+    setLoading(false);
     startTransition(() => {
       router.replace("/dashboard");
     });


### PR DESCRIPTION
This pull request enhances the login security by enforcing an admin-only access policy in the `LoginForm` component. Now, users must have the `admin` role in their metadata to successfully log in; otherwise, they are signed out and shown an error message.

Authentication and access control improvements:

* Added a check after successful authentication to verify that the user's `role` in `user_metadata` is `"admin"`, and if not, the user is signed out and an "Access denied" error is displayed.
* Moved `setLoading(false)` to ensure loading state is properly managed after both authentication and role verification.